### PR TITLE
Add base renovate config

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,7 @@
     "config:base",
     "prConcurrentLimit10"
   ],
-  "semanticCommits": "enabled"
+  "semanticCommits": "enabled",
   "automergeType": "branch",
   "configMigration": true,
   "dependencyDashboard": true,

--- a/default.json
+++ b/default.json
@@ -3,7 +3,7 @@
   "description": "Default preset for use with OpenFeature's repos",
   "extends": [
     "config:base",
-    "prConcurrentLimit10"
+    ":prConcurrentLimit10"
   ],
   "semanticCommits": "enabled",
   "automergeType": "branch",

--- a/default.json
+++ b/default.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Default preset for use with OpenFeature's repos",
   "extends": [
-    "config:base",
-    ":prConcurrentLimit10"
+    "config:base"
   ],
   "semanticCommits": "enabled",
   "automergeType": "branch",

--- a/default.json
+++ b/default.json
@@ -63,5 +63,5 @@
       ],
       "automerge": true
     }
-  ],
+  ]
 }

--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
     "config:base",
     "prConcurrentLimit10"
   ],
+  "semanticCommits": "enabled"
   "automergeType": "branch",
   "configMigration": true,
   "dependencyDashboard": true,

--- a/default.json
+++ b/default.json
@@ -10,7 +10,6 @@
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "rebaseWhen": "behind-base-branch",
-  "platformAutomerge": true,
   "npm": {
     "packageRules": [
       {

--- a/default.json
+++ b/default.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default preset for use with OpenFeature's repos",
+  "extends": [
+    "config:base",
+    "prConcurrentLimit10"
+  ],
+  "automergeType": "branch",
+  "configMigration": true,
+  "dependencyDashboard": true,
+  "prCreation": "not-pending",
+  "rebaseWhen": "behind-base-branch",
+  "platformAutomerge": true,
+  "npm": {
+    "packageRules": [
+      {
+        "matchPackagePatterns": [
+          "@docusaurus/"
+        ],
+        "groupName": "Docusaurus"
+      },
+      {
+        "matchPackagePatterns": [
+          "@typescript-eslint",
+          "eslint"
+        ],
+        "groupName": "ESLint"
+      },
+      {
+        "matchPackagePatterns": [
+          "@fortawesome/"
+        ],
+        "groupName": "Font Awesome"
+      },
+      {
+        "matchPackagePatterns": [
+          "@types/"
+        ],
+        "groupName": "Types"
+      },
+      {
+        "description": "disable package.json > engines update",
+        "matchDepTypes": [
+          "engines"
+        ],
+        "enabled": false
+      }
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true
+    }
+  ],
+}

--- a/default.json
+++ b/default.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Default preset for use with OpenFeature's repos",
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommitTypeAll(chore)"
   ],
   "semanticCommits": "enabled",
   "automergeType": "branch",

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Onboarding preset for use with Renovate's repos",
+  "extends": ["github>open-feature/.github"]
+}


### PR DESCRIPTION
Adds an org wide Renovate configuration that can be included in any repo interested in using it.

A repo can reference shared config like this:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>open-feature/.github"]
}
```

Resources:

- https://github.com/renovatebot/renovate/discussions/10609
- https://wayfair.github.io/docs/managing-dependencies/

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>

