### PR TITLE
chore: add contrib-repo CODEOWNERS reqs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,18 @@ Additionally, we have an org-wide base config for Renovate.
 [conventional-commits]: [https://www.conventionalcommits.org/]
 [semantic-versioning]: [https://semver.org/]
 [release-please]: [https://github.com/googleapis/release-please]
+
+### "Contrib" repositories
+
+Along with SDK repositories, we also maintain "contrib" repositories for most of our supported languages.
+These repositories are "monorepos" that house community contributions which are extensions to, or integrations with, the base SDKs.
+Examples include providers, hooks and framework-specific SDKs.
+In addition to the normal [repository requirements](#repository-requirements) (many of which are already implemented for all packages in each monorepo), components must each have _at least_ one CODEOWNER. It's the responsibility of the CODEOWNER(s) to:
+
+- review and resolve issues pertaining to their component
+- review and resolve pull requests pertaining to their component, including automated pull requests from dependabot, etc
+- release new versions of their component
+  - it's not required to implement new features in new releases, but releases containing dependency updates and bug fixes are expected
+- alert the [Governance Board or Technical Committee](https://github.com/open-feature/community/blob/main/community-members.md#technical-committee) if they're no longer interested or able fulfill the preceding requirements
+
+Consistent and prolonged failure to satisfy the above requirements may result in archival and deprecation of the component in question.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,6 @@ In addition to the normal [repository requirements](#repository-requirements) (m
 - review and resolve pull requests pertaining to their component, including automated pull requests from dependabot, etc
 - release new versions of their component
   - it's not required to implement new features in new releases, but releases containing dependency updates and bug fixes are expected
-- alert the [Governance Board or Technical Committee](https://github.com/open-feature/community/blob/main/community-members.md#technical-committee) if they're no longer interested or able fulfill the preceding requirements
+- alert the [Governance Board or Technical Committee](https://github.com/open-feature/community/blob/main/community-members.md#technical-committee) if they're no longer interested or able to fulfill the preceding requirements
 
 Consistent and prolonged failure to satisfy the above requirements may result in archival and deprecation of the component in question.


### PR DESCRIPTION
- adds requirements decided on by the TC at our Friday Jun 16th meeting:
  - requires CODEOWNERs for contrib components
  - outlines CODEOWNERs responsibilities
 
Supporting tooling and automation will be added to the contribs to support this.

I will be reaching out to contributors to establish CODEOWNERs files for the existing components.