### PR TITLE
chore: CODEOWNERS to component_owners

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,12 +64,11 @@ Additionally, we have an org-wide base config for Renovate.
 Along with SDK repositories, we also maintain "contrib" repositories for most of our supported languages.
 These repositories are "monorepos" that house community contributions which are extensions to, or integrations with, the base SDKs.
 Examples include providers, hooks and framework-specific SDKs.
-In addition to the normal [repository requirements](#repository-requirements) (many of which are already implemented for all packages in each monorepo), components must each have _at least_ one CODEOWNER. It's the responsibility of the CODEOWNER(s) to:
+In addition to the normal [repository requirements](#repository-requirements) (many of which are already implemented for all packages in each monorepo), components must each have _at least_ one user specified the `component_owners.yml` (see https://github.com/dyladan/component-owners for more). It's the responsibility of the `component_owner(s)` to:
 
 - review and resolve issues pertaining to their component
 - review and resolve pull requests pertaining to their component, including automated pull requests from dependabot, etc
-- release new versions of their component
-  - it's not required to implement new features in new releases, but releases containing dependency updates and bug fixes are expected
+- review releases PRs for new versions of their component
 - alert the [Governance Board or Technical Committee](https://github.com/open-feature/community/blob/main/community-members.md#technical-committee) if they're no longer interested or able to fulfill the preceding requirements
 
 Consistent and prolonged failure to satisfy the above requirements may result in archival and deprecation of the component in question.


### PR DESCRIPTION
`component_owners` certainly works better than `CODEOWNERS` for our contrib repos. We've validated this in our `js-sdk-conribs` - so I'm updating the requirement, and I will continue implementing this in all contribs.