### PR TITLE
chore: update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,20 @@
 # Security Policy
-Supported Versions
 
-All versions after 1.x will be supported from a security perspective, unless explicitly end-of-life'd in this document.
+## Supported Versions
+
+As outlined by our [Repository requirements](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md#repository-requirements), OpenFeature artifacts adhere to semantic versioning and include meaningful change logs. The OpenFeature specification includes [Document status](https://github.com/open-feature/spec/tree/main/specification#document-statuses) definitions, which are used to indicate the stability level of each specification section.
 
 ## Reporting a Vulnerability
 
-We don't have a private disclosure mechanism. Please contribute any known vulnerabilities to the issue tracker for the relevant project. If you feel strongly that you don't want to report it publicly, either engage us on slack or the email list. If your vulnerability report is accepted, you'll get named credit (if you so choose) and we'll fix it as expediantly as we can.
+If you find something suspicious and want to report it, we'd really appreciate it!
+
+### Ways to report
+
+- Many repositories provide a way to report vulnerabilities privately to maintainers through a GitHub issue. This can be done by selecting the `Report a vulnerability` template when creating a new issue. Only report vulnerabilities using this template, so the issue can be addressed before public disclosure.
+- Send a message to [cncf-openfeature-maintainers@lists.cncf.io](mailto:cncf-openfeature-maintainers@lists.cncf.io). This option should only be used if the vulnerability template is unavailable.
+
+## Vulnerability Policies
+
+OpenFeature uses Snyk and Trivy vulnerability scans to make sure we minimize vulnerabilities in our dependencies and get notified of new vulnerabilities.
+
+There are many situations where a vulnerability does not affect a particular dependency because of how the vulnerable package is used. In that situation, the package authors may choose to stay at the current version rather than bumping the dependency, leading to a warning in the vulnerability scans but no actual vulnerability.


### PR DESCRIPTION
This is the policy that is automatically injected into all repos, so I'm moving our [policy in community](https://github.com/open-feature/community/blob/main/SECURITY.md) here, and updating the one in community to redirect here.

fixes: https://github.com/open-feature/.github/issues/49