### PR TITLE
chore: improve org-wide readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,16 +1,42 @@
-##  Welcome to the OpenFeature project 👋
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/white/openfeature-horizontal-white.svg">
+    <img align="center" alt="OpenFeature Logo" src="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg" />
+  </picture>
+</p>
 
-[![Sign-up](https://img.shields.io/static/v1?label=Sign-up&message=for%20news&color=blue)](https://lists.cncf.io/g/cncf-openfeature-project)
-[![Specification](https://img.shields.io/static/v1?label=Specification&message=v0.7.0&color=yellow)](https://github.com/open-feature/spec/tree/v0.7.0)
-[![Roadmap](https://img.shields.io/static/v1?label=Roadmap&message=public&color=green)](https://github.com/orgs/open-feature/projects/1)
-[![Governance](https://img.shields.io/static/v1?label=Governance&message=bootstrap&color=yellow)](https://github.com/open-feature/community/blob/main/governance-charter.md)
-[![Contributing](https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue)](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md)
+<h2 align="center">Welcome to the OpenFeature project 👋</h2>
 
-Our goal is to create an open specification for feature flag management to support a robust feature flag ecosystem using cloud native technologies.
+<p align="center">
+  <a href="https://openfeature.dev">OpenFeature</a> is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool or in-house solution.
+</p>
 
-This means:
+<p align="center">
+  <a href="https://openfeature.dev/docs/reference/intro">Learn More 📚</a>
+  ·
+  <a href="https://openfeature.dev/docs/tutorials/five-minutes-to-feature-flags">Get Started 🔭</a>
+  ·
+  <a href="https://openfeature.dev/community/CONTRIBUTOR_LADDER">Contribute 😍</a>
+  ·
+  <a href="https://openfeature.dev/ecosystem">Discover the Ecosystem 🧭</a>
+</p>
 
-* Defining an open standard, vendor-neutral specification.
-* Developing a unified API and SDK.
-* Providing a developer-first, cloud-native implementation.
-* Supporting extensibility for open source and commercial offerings.
+---
+
+## 👋 Getting involved
+
+There is a lot to do! If you're interested in getting involved, please join our [Slack channel](https://github.com/open-feature/community?tab=readme-ov-file#discussions), the [mailing lists](https://github.com/open-feature/community?tab=readme-ov-file#mailing-list), and [attend the community meetings](https://github.com/open-feature/community?tab=readme-ov-file#community-meetings).  We're a friendly, collaborative group and look forward to working together!
+
+Learn how to get involved in the [OpenFeature Contributor Ladder](https://openfeature.dev/community/CONTRIBUTOR_LADDER).
+
+## 🦺 Help keep our community safe, inviting, and inclusive
+
+OpenFeature follows the [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Please abide by this Code of Conduct when interacting with all repositories under the OpenFeature umbrella and when interacting with people.
+
+## 👾 Reporting Security Incidents
+
+Please be mindful that Security-related issues should be reported through our [Security Policy](https://github.com/open-feature/.github/blob/main/SECURITY.md) as Security-related issues and vulnerabilities can be exploited and we request confidentiality whenever possible.
+
+---
+
+OpenFeature is a [CNCF](https://cncf.io/) [incubating](https://www.cncf.io/projects/) project.


### PR DESCRIPTION
## This PR

- improve the org readme
- added multiple quick links to important areas of the project.

### Notes

This is very much inspired by what [OpenTelemetry has](https://github.com/open-telemetry). I think it creates a good balance between being useful without being an ongoing maintenance burden.
