### PR TITLE
feat: add federated SDK issue template and management workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/all-sdks.yml
+++ b/.github/ISSUE_TEMPLATE/all-sdks.yml
@@ -1,0 +1,41 @@
+name: Federated SDK issue template
+description: |
+  Federated issue management across all OpenFeature SDKs.
+  Please note that sub-issues will only be created for authorized users.
+labels:
+  - federated
+  - sdk
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Federated SDK issue template
+        This issue is for creating sub-issues across all OpenFeature SDKs.
+        Please note that sub-issues will only be created for authorized users.
+        If you are not authorized, please create a new issue in the relevant SDK repository.
+  - type: textarea
+    attributes:
+      label: Parent issue description
+      description: The description of the parent issue.
+      value: |
+        Please add information about the issue you want to create.
+        You can use Markdown syntax to format your text.
+  - type: markdown
+    attributes:
+      value: |
+        ## Sub-Issue Creation
+        Please provide the details for the sub-issue you want to create.
+        The sub-issue will be created in the relevant SDK repository.
+  - type: input
+    id: sub-issue-title
+    attributes:
+      label: Sub-Issue Title
+      description: The title of the sub-issue.
+  - type: textarea
+    id: sub-issue-body
+    attributes:
+      label: Implementation Details
+      description: |
+        Please provide a detailed description of the implementation details for the sub-issue.
+        You can use Markdown syntax to format your text.

--- a/.github/sdk-issue-config.json
+++ b/.github/sdk-issue-config.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/beeme1mr/federated-issue-action/refs/tags/v1/config.schema.json",
+  "allowed": {
+    "teams": [
+      "technical-steering-committee",
+      "governance-board"
+    ]
+  },
+  "targetRepositorySelectors": [
+    {
+      "method": "name-pattern",
+      "pattern": "-sdk",
+      "operator": "ends-with"
+    }
+  ]
+}

--- a/.github/workflows/sdk-issue-management.yml
+++ b/.github/workflows/sdk-issue-management.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   demo:
     runs-on: ubuntu-latest
+    environment: issue-management
     if: contains(github.event.issue.labels.*.name, 'federated') && contains(github.event.issue.labels.*.name, 'sdk')
     steps:
       - name: Checkout repository

--- a/.github/workflows/sdk-issue-management.yml
+++ b/.github/workflows/sdk-issue-management.yml
@@ -1,0 +1,27 @@
+name: Federated SDK issue management
+
+on:
+  issues:
+    types: [edited, closed, labeled, unlabeled]
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'federated') && contains(github.event.issue.labels.*.name, 'sdk')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/all-sdks.yaml
+
+      - name: Manage parent and sub-issues
+        uses: beeme1mr/federated-issue-action@v1
+        with:
+          github-token: ${{ secrets.ISSUE_MANAGEMENT_PAT }}
+          config-path: .github/sdk-issue-config.json
+          child-issue-title: ${{ steps.issue-parser.outputs.issueparser_sub-issue-title }}
+          child-issue-body: ${{ steps.issue-parser.outputs.issueparser_sub-issue-body }}


### PR DESCRIPTION
## This PR

- adds a workflow to manage issues in all SDKs

### Notes

It has started to become tedious to create and manage issues across all of our SDKs. Recently, we decided to update the READMEs to explicitly mention that `setProviderAndWait` can throw. I started to manually create those issues, but then pivoted to building this action. I hope that this can be used to quickly and easily manage requirements across all of our SDKs.

### How to test

I haven't been able to test the action in a org yet but you can see how it works [here](https://github.com/beeme1mr/federated-issue-action/issues/11).

